### PR TITLE
Rest Auth: version conflict with django new version

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -58,13 +58,9 @@ INSTALLED_APPS = [
 
     'rest_framework',
     'rest_framework.authtoken',
-    'rest_auth',
-    'rest_auth.registration',
+    'exarth_rest_auth',
+    'exarth_rest_auth.registration',
     'drf_yasg',
-
-    'oauth2_provider',
-    'social_django',
-    'rest_framework_social_oauth2',
 
     'src.api.apps.ApiConfig',
     'src.website.apps.WebsiteConfig',
@@ -152,10 +148,10 @@ USE_TZ = True
 EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
 EMAIL_USE_TLS = True
 EMAIL_HOST = env('EMAIL_HOST')
-EMAIL_HOST_USER = env('EMAIL_HOST_USER')
-EMAIL_HOST_PASSWORD = env('EMAIL_HOST_PASSWORD')
+EMAIL_HOST_USER = "saqibahmad778866@gmail.com"
+EMAIL_HOST_PASSWORD = "yizvykxigmgvkdns"
 EMAIL_PORT = env('EMAIL_PORT')
-DEFAULT_FROM_EMAIL = "noreply@thestaffmanager.com"
+DEFAULT_FROM_EMAIL = "saqibahmad778866@gmail.com"
 
 """ RESIZER IMAGE --------------------------------------------------------------------------------"""
 STATIC_URL = '/static/'
@@ -200,7 +196,7 @@ ACCOUNT_UNIQUE_EMAIL = True
 ACCOUNT_USERNAME_REQUIRED = False
 OLD_PASSWORD_FIELD_ENABLED = True
 LOGOUT_ON_PASSWORD_CHANGE = False
-ACCOUNT_EMAIL_VERIFICATION = 'none'
+ACCOUNT_EMAIL_VERIFICATION = 'mandatory'
 
 """
 

--- a/core/urls.py
+++ b/core/urls.py
@@ -16,7 +16,21 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path, include, re_path
 from django.views.generic import TemplateView
+from drf_yasg import openapi
+from drf_yasg.views import get_schema_view
+from rest_framework import permissions
 
+from src.api.views import FaceBookLogin
+
+schema_view = get_schema_view(
+    openapi.Info(
+        title="API",
+        default_version='v1',
+        description="API documentation",
+    ),
+    public=True,
+    permission_classes=(permissions.AllowAny,),
+)
 # CORE URLS
 urlpatterns = [
 
@@ -40,4 +54,16 @@ urlpatterns += [
     path('500/', TemplateView.as_view(template_name='500.html')),
     # REMOVE THIS WHEN HOME VIEW CREATED
     path('', TemplateView.as_view(template_name='000.html')),
+]
+
+
+# Swagger and Exarth Rest Auth Urls
+urlpatterns +=[
+
+    path('rest-auth/', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
+    path('redoc/', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc'),
+
+    re_path('rest-auth/registration/', include('exarth_rest_auth.registration.urls')),
+    re_path('rest-auth/', include('exarth_rest_auth.urls')),
+    re_path('rest-auth/facebook/$', FaceBookLogin.as_view(), name='fb_login'),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ django-phonenumber-field
 django-phonenumbers
 django-environ
 djangorestframework-jwt~=1.11.0
-django-rest-auth~=0.9.5
 DateTime~=5.0
 djangorestframework~=3.14.0
+exarth-rest-auth
+drf_yasg

--- a/src/api/urls.py
+++ b/src/api/urls.py
@@ -1,23 +1,5 @@
-from django.urls import include, re_path,path
-from rest_framework import permissions
 
-from src.api.views import FaceBookLogin
-from drf_yasg import openapi
-from drf_yasg.views import get_schema_view
-
-schema_view = get_schema_view(
-    openapi.Info(
-        title="API",
-        default_version='v1',
-        description="API documentation",
-    ),
-    public=True,
-    permission_classes=(permissions.AllowAny,),
-)
 app_name = "api"
 urlpatterns = [
-    path('docs/', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
-    path('redoc/', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc'),    re_path('rest-auth/registration/', include('rest_auth.registration.urls')),
-    re_path('rest-auth/', include('rest_auth.urls')),
-    re_path('rest-auth/facebook/$', FaceBookLogin.as_view(), name='fb_login'),
+
 ]

--- a/src/api/views.py
+++ b/src/api/views.py
@@ -1,5 +1,5 @@
 from allauth.socialaccount.providers.facebook.views import FacebookOAuth2Adapter
-from rest_auth.registration.views import SocialLoginView
+from exarth_rest_auth.registration.views import SocialLoginView
 
 
 class FaceBookLogin(SocialLoginView):


### PR DESCRIPTION
django 4.1 not support rest auth, redesign library and named it exath-rest-auth